### PR TITLE
Fix wrong parameter to DataObject::get in AIAutoTranslate Task

### DIFF
--- a/src/Task/AIAutoTranslate.php
+++ b/src/Task/AIAutoTranslate.php
@@ -101,7 +101,7 @@ class AIAutoTranslate extends BuildTask
             echo PHP_EOL . '** ' . $fluentClass->singular_name() . ' **' . PHP_EOL;
             $translatableItems = FluentState::singleton()
                 ->setLocale($defaultLocale)
-                ->withState(static fn(FluentState $state) => DataObject::get($fluentClass));
+                ->withState(static fn(FluentState $state) => DataObject::get($fluentClassName));
             foreach ($translatableItems as $translatableItem) {
                 $translatableItem = $translatableItem->fixLastTranslationForDefaultLocale();
                 $status = $translatableItem->autoTranslate($doPublish, $forceTranslation);


### PR DESCRIPTION
Heyo,

I wasn't able to run the task out of the box, it always threw a 500 error on the line.
As I understand, the parameter should be a class string (https://github.com/silverstripe/silverstripe-framework/blob/5/src/ORM/DataObject.php#L3440), but right now the whole object is passed into it.