### PR TITLE
Fix getGPTCommand method to include targetLocale in extend call

### DIFF
--- a/src/Control/AITranslateController.php
+++ b/src/Control/AITranslateController.php
@@ -77,8 +77,6 @@ class AITranslateController extends Controller
 
     public function doTranslate(array $data, Form $form)
     {
-        $doPublish = $data['doPublish'] ?? false;
-        $forceTranslation = $data['forceTranslation'] ?? false;
         //@todo ability to filter locales to translate to
         if (!array_key_exists('ID', $data) || !array_key_exists('ClassName', $data)) {
             $this->httpError(400, 'ID and ClassName required');
@@ -98,7 +96,7 @@ class AITranslateController extends Controller
         }
 
 //        Versioned::set_stage(Versioned::DRAFT);
-        $status = $object->doRecursiveAutoTranslate($data, $forceTranslation);
+        $status = $object->doRecursiveAutoTranslate($data, $form);
 
         $templates = SSViewer::get_templates_by_class(self::class, '_' . __FUNCTION__);
 

--- a/src/Translator/ChatGPTTranslator.php
+++ b/src/Translator/ChatGPTTranslator.php
@@ -95,7 +95,7 @@ class ChatGPTTranslator implements Translatable
         $command = self::config()->get('gpt_command');
 
         // Erweiterung der Befehlslogik durch andere Klassen
-        $this->extend('updateGPTCommand', $command);
+        $this->extend('updateGPTCommand', $command, $targetLocale);
 
         return sprintf($command, $targetLocale);
     }


### PR DESCRIPTION
The README.md has a passage about extending the prompt dynamically, but the $locale parameter is not passed to the extension call.

```php
public function updateGptCommand(&$command, $locale)
{
    $command = 'You are a professional translator. Translate the following text to ' . $locale . ' language. Please keep the json format intact.';
}
```